### PR TITLE
Send detailed occupancy info for each map

### DIFF
--- a/uclapi/workspaces.js
+++ b/uclapi/workspaces.js
@@ -103,6 +103,12 @@ const getAllSeatInfo = async () => {
     ...reduceSeatInfo(survey.maps),
     name: survey.name,
     id: survey.id,
+    maps: survey.maps.map(map => ({
+      id: map.id,
+      name: map.name,
+      occupied: map.sensors_occupied,
+      capacity: map.sensors_absent + map.sensors_other + map.sensors_occupied,
+    })),
   }));
 };
 


### PR DESCRIPTION
This sends the data that is necessary to address [Library Rooms Availability #4](https://github.com/uclapi/ucl-assistant-app/issues/4) in ucl-assistant-api.

Right now, only the overall occupancy and capacity is sent for each survey (for the `/workspaces/summary` endpoint):
```
{
      "occupied": 28,
      "total": 63,
      "name": "UCL Wolfson Study",
      "id": 22
}
```

This PR sends breakdowns for individual maps back as well, e.g.:
```
{
      "occupied": 7,
      "total": 172,
      "name": "UCL SSEES Library",
      "id": 39,
      "maps": [
        {
          "id": 99,
          "name": "Basement",
          "occupied": 0,
          "capacity": 56
        },
        {
          "id": 100,
          "name": "Ground",
          "occupied": 0,
          "capacity": 3
        },
        {
          "id": 101,
          "name": "First",
          "occupied": 2,
          "capacity": 73
        },
        {
          "id": 102,
          "name": "Second",
          "occupied": 5,
          "capacity": 40
        }
      ]
}
```