### PR TITLE
Support specifying start & end datetimes for /freerooms

### DIFF
--- a/constants/indexRoutes.js
+++ b/constants/indexRoutes.js
@@ -59,7 +59,13 @@ const indexRoutes = {
         date: `Date expressed in ISO8601, i.e. YYYYMMDD`,
       },
     },
-    "/freerooms": `Returns all rooms free between now and the end of the day`,
+    "/freerooms": {
+      description: `Returns all rooms free between now and the end of the day`,
+      parameters: {
+        start_datetime: `Start datetime in ISO8601 format, e.g. 2011-03-06T03:36:45+00:00`,
+        end_datetime: `End datetime in ISO8601 format, e.g. 2011-03-06T03:36:45+00:00`,
+      },
+    },
     "/ping": `returns a 200 OK message. good for testing liveness`,
     "/echo": `returns the HTTP message body as the content`,
   },

--- a/uclapi/app.js
+++ b/uclapi/app.js
@@ -159,7 +159,11 @@ router.get(`/roombookings`, jwt, async ctx => {
 })
 
 router.get(`/freerooms`, jwt, async ctx => {
-  ctx.body = await getFreeRooms()
+  const {
+    start_datetime: startDateTime,
+    end_datetime: endDateTime,
+  } = ctx.query
+  ctx.body = await getFreeRooms(startDateTime, endDateTime)
 })
 
 app.use(router.routes())


### PR DESCRIPTION
So the app can put in a request for all rooms free in the next hour.

See [#20 Display closest empty room](https://github.com/uclapi/ucl-assistant-app/issues/20)