### PR TITLE
Ignore BadRequests and NotFound errors

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -49,7 +49,9 @@ const jsonify = async (ctx, next) => {
   try {
     await next()
   } catch (error) {
-    Sentry.captureException(error)
+    if (![400, 404].includes(error.status)) {
+      Sentry.captureException(error)
+    }
     if (typeof error.message === `string`) {
       console.error(`Error: ${error.message}\n${error.stack}`)
       ctx.error = error.message


### PR DESCRIPTION
We're not really bothered by 400s and 404s.